### PR TITLE
Fix FAQ answer cutoff on mobile by updating max-height for active items

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -2584,7 +2584,7 @@ ul {
   transform: rotate(180deg);
 }
 .faq-section .faq-wrapper .faq-list-wrapper.active .faq-title-description {
-  max-height: 100px; /* large enough to fit content */
+  max-height: none;
 }
 .faq-section .faq-wrapper .faq-list-wrapper .faq-list-title {
   font-size: 1rem;

--- a/styles/sections/_faq.scss
+++ b/styles/sections/_faq.scss
@@ -20,7 +20,7 @@
         }
 
         .faq-title-description {
-          max-height: 100px; /* large enough to fit content */
+          max-height: none/* allows the content to expand to its full ht */
         }
       }
 


### PR DESCRIPTION
This PR fixes an issue where FAQ answers were being cut off on mobile devices. 